### PR TITLE
Recipe for installation of web proxy services on CentOS7.x + Windows 2012R2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,10 +6,10 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-6.4
+  - name: centos-7.1
 
 suites:
   - name: default
     run_list:
-      - recipe[netapp_e::default]
+      - recipe[netapp_e::proxy]
     attributes:

--- a/files/default/linux_installer.properties
+++ b/files/default/linux_installer.properties
@@ -1,0 +1,71 @@
+# Replay feature output
+
+# ---------------------
+
+# This file was built by the Replay feature of InstallAnywhere.
+
+# It contains variables that were set by Panels, Consoles or Custom Code.
+
+
+
+INSTALLER_UI=silent 
+
+
+
+LICENSE_ACCEPTED=TRUE
+
+
+
+#Choose Install Folder
+
+#---------------------
+
+USER_INSTALL_DIR=/opt/netapp/santricity_web_services_proxy
+
+
+
+#Auto Update Feature
+
+#-------------------
+
+ENABLE_AUTO_UPDATES=1
+
+DISABLE_AUTO_UPDATES=0
+
+
+
+#AutoSupport
+
+#-----------
+
+ENABLE_ASUP=1
+
+DISABLE_ASUP=0
+
+
+
+#Enter the SSL and Non SSL Jetty Port Numbers
+
+#--------------------------------------------
+
+JETTYPORT_SSL=8443
+
+JETTYPORT=8080
+
+
+
+#Install
+
+#-------
+
+-fileOverwrite_/opt/netapp/santricity_web_services_proxy/eula.html=Yes
+
+-fileOverwrite_/opt/netapp/santricity_web_services_proxy/uninstall_web_services_proxy/uninstall_web_services_proxy.lax=Yes
+
+-fileOverwrite_/opt/netapp/santricity_web_services_proxy/uninstall_web_services_proxy/uninstall_web_services_proxy.ico=Yes
+
+-fileOverwrite_/opt/netapp/santricity_web_services_proxy/securepasswords.lax=Yes
+
+-fileOverwrite_/opt/netapp/santricity_web_services_proxy/UpdateJREPath.sh=Yes
+
+-fileOverwrite_/etc/init.d/web_services_proxy=Yes

--- a/files/default/windows_installer.properties
+++ b/files/default/windows_installer.properties
@@ -1,0 +1,41 @@
+# Wed Nov 18 02:25:25 PST 2015
+# Replay feature output
+# ---------------------
+# This file was built by the Replay feature of InstallAnywhere.
+# It contains variables that were set by Panels, Consoles or Custom Code.
+
+INSTALLER_UI=silent 
+
+LICENSE_ACCEPTED=TRUE
+
+#Choose Install Folder
+#---------------------
+USER_INSTALL_DIR=C:\\Program Files\\NetApp\\SANtricity Web Services Proxy
+
+#Auto Update Feature
+#-------------------
+ENABLE_AUTO_UPDATES=1
+DISABLE_AUTO_UPDATES=0
+
+#AutoSupport
+#-----------
+ENABLE_ASUP=1
+DISABLE_ASUP=0
+
+#Enter the SSL and Non SSL Jetty Port Numbers
+#--------------------------------------------
+JETTYPORT_SSL=8443
+JETTYPORT=8080
+
+#Install
+#-------
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\eula.html=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\uninstall_web_services_proxy\\uninstall_web_services_proxy.lax=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\uninstall_web_services_proxy\\resource\\iawin64_x64.dll=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\uninstall_web_services_proxy\\resource\\win64_32_x64.exe=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\uninstall_web_services_proxy\\resource\\remove.exe=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\uninstall_web_services_proxy\\resource\\invoker.exe=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\uninstall_web_services_proxy\\uninstall_web_services_proxy.ico=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\securepasswords.lax=Yes
+-fileOverwrite_C\:\\Program\ Files\\NetApp\\SANtricity\ Web\ Services\ Proxy\\UpdateJREPath.bat=Yes
+

--- a/recipes/proxy.rb
+++ b/recipes/proxy.rb
@@ -49,5 +49,34 @@ when 'ubuntu', 'centos', 'redhat', 'fedora'
     action :delete
   end
 
+when 'windows'
+  # Default installation path is C:\Program Files\NetApp\ . Skip installation if this directory exists.
+  return if File.directory? 'C:\Program Files\NetApp\\'
+
+  cookbook_file 'C:\installer.properties' do
+    source 'windows_installer.properties'
+    rights :full_control, 'Everyone' 
+    action :create
+  end
+
+  remote_file 'web_proxy' do
+    source 'https://googledrive.com/host/0B4gqXBcuZgSEUDBwYkxYWTRJZ1k/webservice-01.30.3000.0003.exe'
+    path 'C:\webservice-01.30.3000.0003.exe'
+    rights :full_control, 'Everyone' 
+    action :create
+  end
+
+  execute 'install_web_proxy' do
+    command 'C:\webservice-01.30.3000.0003.exe -f C:\installer.properties'
+  end
+
+  file 'C:\webservice-01.30.3000.0003.exe' do
+    action :delete
+  end
+
+  file 'C:\installer.properties' do
+    action :delete
+  end
+
 end
 

--- a/recipes/proxy.rb
+++ b/recipes/proxy.rb
@@ -23,17 +23,31 @@ when 'ubuntu', 'centos', 'redhat', 'fedora'
   return if File.directory? '/opt/netapp/'
 
   remote_file 'web_proxy' do
-    source 'https://example.com/webservice-01.00.7000.0003.bin'
-    path '/tmp/webservice-01.00.7000.0003.bin'
+    source 'https://example.com/webservice-01.30.7000.0002.bin'
+    path '/tmp/webservice-01.30.7000.0002.bin'
+    mode '0777'
+    action :create
+  end
+
+  cookbook_file '/tmp/installer.properties' do
+    source 'linux_installer.properties'
+    owner 'root'
+    group 'root'
     mode '0777'
     action :create
   end
 
   bash 'install_web_proxy' do
-    code '/tmp/webservice-01.00.7000.0003.bin -i silent'
+    code '/tmp/webservice-01.30.7000.0002.bin -f /tmp/installer.properties'
   end
 
-  file '/tmp/webservice-01.00.7000.0003.bin' do
+  file '/tmp/webservice-01.30.7000.0002.bin' do
     action :delete
   end
+
+  file '/tmp/installer.properties' do
+    action :delete
+  end
+
 end
+


### PR DESCRIPTION
Recipe for installation of web proxy services on CentOS 7.x and Windows 2012R2 is checked in.
Testing for various scenarios are in-progress.
