### PR TITLE
Host group attributes are used for inputs, instead of hardcoded values

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ default['netapp']['ssl_port'] = 8443
 ############ timeout (optional) ######################
 # default['netapp']['api']['timeout'] = 60000
 
-default['netapp']['storage_system_ip'] = '10.113.1.18'
+default['netapp']['storage_system_ip'] = '127.0.0.1'
 
 # mirror group
 default['netapp']['mirror_group']['name'] = 'mirror_group'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,12 @@ default['netapp']['ssl_port'] = 8443
 ############ timeout (optional) ######################
 # default['netapp']['api']['timeout'] = 60000
 
+default['netapp']['storage_system_ip'] = '10.113.1.18'
+
 # mirror group
-default['netapp']['storage_system_ip'] = '10.113.1.130'
 default['netapp']['mirror_group']['name'] = 'mirror_group'
 default['netapp']['mirror_group']['secondary_array_id'] = 'e9f486b8-8634-4f58-9563-c57561633376'
+
+# host group
+default['netapp']['host_group']['name'] = 'testy_host_group'
+# default['netapp']['host_group']['hosts'] = ['8400000060080E50001F6D3800300DFE565E8364','8400000060080E50001F69B400300EDE565E8283'] # optional parameter

--- a/libraries/netapp_e_series_api.rb
+++ b/libraries/netapp_e_series_api.rb
@@ -98,7 +98,7 @@ class NetApp
         return false if host_grp_id.nil?
 
         response = request(:delete, "/devmgr/v2/storage-systems/#{sys_id}/host-groups/#{host_grp_id}")
-        status(response, 200, [200], 'Failed to delete host group')
+        status(response, 204, [204], 'Failed to delete host group')
       end
 
       # Call storage-pool API /devmgr/v2/{storage-system-id}/storage-pools to create a volume group or a disk pool.

--- a/recipes/host_group.rb
+++ b/recipes/host_group.rb
@@ -20,12 +20,10 @@
 netapp_e_host_group node['netapp']['host_group']['name'] do
   storage_system node['netapp']['storage_system_ip']
   hosts node['netapp']['host_group']['hosts']
-  
   action :create
 end
 
 netapp_e_host_group node['netapp']['host_group']['name'] do
   storage_system node['netapp']['storage_system_ip']
-
   action :delete
 end

--- a/recipes/host_group.rb
+++ b/recipes/host_group.rb
@@ -17,14 +17,15 @@
 # limitations under the License.
 #
 
-netapp_e_host_group 'demo_group' do
-  storage_system '10.250.117.112'
-
+netapp_e_host_group node['netapp']['host_group']['name'] do
+  storage_system node['netapp']['storage_system_ip']
+  hosts node['netapp']['host_group']['hosts']
+  
   action :create
 end
 
-netapp_e_host_group 'demo_group' do
-  storage_system '10.250.117.112'
+netapp_e_host_group node['netapp']['host_group']['name'] do
+  storage_system node['netapp']['storage_system_ip']
 
   action :delete
 end

--- a/spec/netapp_e_series_api_spec.rb
+++ b/spec/netapp_e_series_api_spec.rb
@@ -233,7 +233,7 @@ describe 'netapp_e_series_api' do
       expect(@netapp_api).to receive(:storage_system_id).with('10.0.0.1').and_return('12345')
       expect(@netapp_api).to receive(:host_group_id).with('12345', 'demo_host_group').and_return('111111')
       expect(@netapp_api).to receive(:request).with(:delete, '/devmgr/v2/storage-systems/12345/host-groups/111111').and_return(response)
-      expect(@netapp_api).to receive(:status).with(response, 200, [200], 'Failed to delete host group')
+      expect(@netapp_api).to receive(:status).with(response, 204, [204], 'Failed to delete host group')
 
       @netapp_api.delete_host_group('10.0.0.1', 'demo_host_group')
     end


### PR DESCRIPTION
Inputs are now accepted from attributes instead of hard coding those values in recipe
